### PR TITLE
A few bugs involved "tests.sh"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+.vscode/
+.ipynb_checkpoints
+*/.ipynb_checkpoints
+__pycache__
+*/__pycache__

--- a/examples/college_admission_util_test.py
+++ b/examples/college_admission_util_test.py
@@ -75,7 +75,8 @@ class CollegeAdmissionUtilTest(absltest.TestCase):
     referred to in college_admission_config.gin configuration file.
     """
     gin.parse_config_file(
-        'third_party/py/fairness_gym/examples/config/'
+        # 'third_party/py/fairness_gym/examples/config/'
+        'examples/config/'
         'college_admission_config.gin')
     runner = runner_lib.Runner()
     runner.run()

--- a/examples/config/college_admission_config.gin
+++ b/examples/config/college_admission_config.gin
@@ -1,9 +1,17 @@
-import fairness_gym.agents.college_admission_jury
-import fairness_gym.environments.college_admission
-import fairness_gym.examples.college_admission_util
-import fairness_gym.metrics.error_metrics
-import fairness_gym.metrics.value_tracking_metrics
-import fairness_gym.runner_lib
+# import fairness_gym.agents.college_admission_jury
+# import fairness_gym.environments.college_admission
+# import fairness_gym.examples.college_admission_util
+# import fairness_gym.metrics.error_metrics
+# import fairness_gym.metrics.value_tracking_metrics
+# import fairness_gym.runner_lib
+
+import agents.college_admission_jury
+import environments.college_admission
+import examples.college_admission_util
+import metrics.error_metrics
+import metrics.value_tracking_metrics
+import runner_lib
+
 
 # Configure the runner.
 Runner.num_steps = 3000

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ simplejson
 sklearn
 statsmodels
 tqdm
+
+gin-config==0.1.1
+mock


### PR DESCRIPTION
When I attempted to install this package following [Installation instructions](https://github.com/google/ml-fairness-gym/blob/master/docs/installation.md), a few bugs occurred. Here is how I fixed them.  

**Bugs occurred when running "tests.sh":**
-  python ./agents/infectious_disease_agents_test.py
-  python ./examples/college_admission_util_test.py
-  python ./examples/college_admission_util_test.py

**Solutions:**
-  pip install gin-config==0.1.1
-  pip install mock
-  modified two files:  "examples/college_admission_util_test.py" and "examples/config/college_admission_config.gin"

**Detailed error information:**

(1) "pip install gin-config==0.1.1" is for the test
```sh
$ python ./agents/infectious_disease_agents_test.py
Traceback (most recent call last):
  File "./agents/infectious_disease_agents_test.py", line 24, in <module>
    import core
  File "/home/byj/GitHubLab/ml-fairness-gym/core.py", line 31, in <module>
    import gin
ImportError: No module named 'gin'
```

(2) "pip install mock" is for the test:
```sh
$ python ./examples/college_admission_util_test.py
Traceback (most recent call last):
  File "./examples/college_admission_util_test.py", line 25, in <module>
    import mock
ImportError: No module named 'mock'
```

(3) modified two files for the test

```sh
$ python examples/college_admission_util_test.py
Running tests under Python 3.5.2: /home/byj/software/python35/bin/python3
[ RUN      ] CollegeAdmissionUtilTest.test_accuracy_nr_fn_returns_whether_predictions_correct
[       OK ] CollegeAdmissionUtilTest.test_accuracy_nr_fn_returns_whether_predictions_correct
[ RUN      ] CollegeAdmissionUtilTest.test_example_configuration_runs
[  FAILED  ] CollegeAdmissionUtilTest.test_example_configuration_runs
[ RUN      ] CollegeAdmissionUtilTest.test_social_burden_eligible_auditor_selects_eligible
[       OK ] CollegeAdmissionUtilTest.test_social_burden_eligible_auditor_selects_eligible
[ RUN      ] CollegeAdmissionUtilTest.test_stratify_by_group_returns_correct_groups
[       OK ] CollegeAdmissionUtilTest.test_stratify_by_group_returns_correct_groups
[ RUN      ] CollegeAdmissionUtilTest.test_stratify_to_one_group_stratifies_to_one_group
[       OK ] CollegeAdmissionUtilTest.test_stratify_to_one_group_stratifies_to_one_group
======================================================================
ERROR: test_example_configuration_runs (__main__.CollegeAdmissionUtilTest)
test_example_configuration_runs (__main__.CollegeAdmissionUtilTest)
Test the college admission runner end-to-end.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "examples/college_admission_util_test.py", line 78, in test_example_configuration_runs
    'third_party/py/fairness_gym/examples/config/'
  File "/home/byj/software/python35/lib/python3.5/site-packages/gin/config.py", line 1438, in parse_config_file
    raise IOError('Unable to open file: {}'.format(config_file))
OSError: Unable to open file: third_party/py/fairness_gym/examples/config/college_admission_config.gin

----------------------------------------------------------------------
Ran 5 tests in 0.003s

FAILED (errors=1)
```





   